### PR TITLE
Fix for issue 9: Replaced complex generator logic with a deep flatten and chunk

### DIFF
--- a/source/dsm.js
+++ b/source/dsm.js
@@ -1,20 +1,10 @@
+const flow = require('lodash/fp/flow');
+const flattenDeep = require('lodash/fp/flattenDeep');
+const chunk = require('lodash/fp/chunk');
 const camelCase = require('lodash.camelcase');
 const snakeCase = require('lodash.snakecase');
 
-const parseNode = node => {
-  const data = node.slice(0, 2);
-  const child = node.slice(2);
-  return { data, child };
-};
-
-function* getStates (graph) {
-  for (let i = 0; i < graph.length; i++) {
-    const { data, child } = parseNode(graph[i]);
-
-    if (Array.isArray(data)) yield data;
-    if (Array.isArray(child)) yield* getStates(child);
-  }
-}
+const getStates = graph => flow(flattenDeep, chunk(2))(graph);
 
 const formatConstant = text => snakeCase(text).toUpperCase();
 


### PR DESCRIPTION
I'm something of an outsider, so I'm not 100% sure of what the getStates requirements were.  But looking at the logic and test cases, simply flattening the array and chunking (with size=2) should be preferable over a complex, recursive replacement.

Passes tests.  If this is not an adequate replacement, a more complex test should be devised showing more full range of acceptable input/output.

David Ash (tw: netjumpio)