### PR TITLE
Fix for issue 9 - replaced generator function with recursive function

### DIFF
--- a/source/dsm.js
+++ b/source/dsm.js
@@ -7,14 +7,16 @@ const parseNode = node => {
   return { data, child };
 };
 
-function* getStates (graph) {
-  for (let i = 0; i < graph.length; i++) {
-    const { data, child } = parseNode(graph[i]);
+const getStates = (graph, initialMemo = []) => (
+  graph.reduce((memo, node) => {
+    const { data, child } = parseNode(node);
 
-    if (Array.isArray(data)) yield data;
-    if (Array.isArray(child)) yield* getStates(child);
-  }
-}
+    if (Array.isArray(data)) memo = memo.concat([data]);
+    if (Array.isArray(child)) memo = getStates(child, memo);
+
+    return memo;
+  }, initialMemo)
+);
 
 const formatConstant = text => snakeCase(text).toUpperCase();
 


### PR DESCRIPTION
Different approach compared to https://github.com/ericelliott/redux-dsm/pull/11 - Rather than just doing a deep flatten and chunking, this approach uses a recursive reducer to achieve the same end, but in a way that should be forward compatible with @ericelliott 's planned "allowable transitions" idea.

> Flattening the array is good thinking but it's also a lossy opperation, meaning that we'll
> lose the information about which transitions are allowed in which states. That feature
> has not been implemented yet. I was thinking of automatically creating a new reducer
> for each state with valid transitions.

