### PR TITLE
Fix for issue 5: Per-status reducers (parent reducers) solution

### DIFF
--- a/source/dsm.js
+++ b/source/dsm.js
@@ -1,18 +1,20 @@
 const camelCase = require('lodash.camelcase');
 const snakeCase = require('lodash.snakecase');
 
+const defaultStatus = 'idle';
+
 const parseNode = node => {
   const data = node.slice(0, 2);
   const child = node.slice(2);
   return { data, child };
 };
 
-const getStates = (graph, initialMemo = []) => (
+const getStates = (graph, initialMemo = [], parentStatus = defaultStatus) => (
   graph.reduce((memo, node) => {
     const { data, child } = parseNode(node);
 
-    if (Array.isArray(data)) memo = memo.concat([data]);
-    if (Array.isArray(child)) memo = getStates(child, memo);
+    if (Array.isArray(data)) memo = memo.concat([data.concat([parentStatus])]);
+    if (Array.isArray(child)) memo = getStates(child, memo, data[1]);
 
     return memo;
   }, initialMemo)
@@ -25,14 +27,13 @@ const empty = {
 };
 
 const defaultState = {
-  status: 'idle',
+  status: defaultStatus,
   payload: empty
 };
 
-const createReducer = (defaultState, reducerMap) => {
+const createReducer = (defaultState, parentReducerMap) => {
   return (state = defaultState, action = {}) => {
-    const { type } = action;
-    const reducer = reducerMap[type];
+    const reducer = parentReducerMap[state.status];
 
     if (typeof reducer === 'function') {
       return reducer(state, action);
@@ -65,16 +66,28 @@ const dsm = ({
       formatConstant(a[0])
     ].join('');
     const status = a[1];
+    const parentStatus = a[2];
 
     return {
       action,
-      status
+      status,
+      parentStatus
     };
   });
   const actions = actionMap.map(a => a.action);
 
+  const parentStatuses = Object.keys(actionMap.reduce((map, a) => {
+    map[a.parentStatus] = true;
+    return map;
+  }, {}));
+
+  const initialReducerMap = parentStatuses.reduce((map, status) => {
+    map[status] = {};
+    return map;
+  }, {});
+
   const reducerMap = actionMap.reduce((map, a) => {
-    map[a.action] = (state = defaultState, action = {}) => {
+    map[a.parentStatus][a.action] = (state = defaultState, action = {}) => {
 
       if (action.type === a.action) {
         const { status } = a;
@@ -88,9 +101,24 @@ const dsm = ({
       return state;
     };
     return map;
+  }, initialReducerMap);
+
+  const parentReducerMap = parentStatuses.reduce((map, status) => {
+    map[status] = (state = defaultState, action = {}) => {
+
+      const { type } = action;
+      const reducer = reducerMap[status][type];
+
+      if (typeof reducer === 'function') {
+        return reducer(state, action);
+      }
+
+      return state;
+    };
+    return map;
   }, {});
 
-  const reducer = createReducer(defaultState, reducerMap);
+  const reducer = createReducer(defaultState, parentReducerMap);
   const actionCreatorNames = getActionCreatorNames(states);
   const actionCreators = actionCreatorNames.reduce((acs, description, i) => {
     acs[description] = payload => ({

--- a/source/test/test.js
+++ b/source/test/test.js
@@ -137,6 +137,34 @@ test('dsm() reducer', nest => {
     assert.same(actual, expected, msg);
     assert.end();
   });
+
+  nest.test('with nested state', assert => {
+    const msg = 'should transition to correct state';
+    const action = {
+      type: 'myComponent::FETCH_FOO::FETCH'
+    };
+    const reducer = dsm(mockOptions()).reducer;
+
+    const actual = reducer(undefined, action).status;
+    const expected = 'fetching';
+
+    assert.same(actual, expected, msg);
+    assert.end();
+  });
+
+  nest.test('with nested state', assert => {
+    const msg = 'should ignore invalid action for current state';
+    const action = {
+      type: 'myComponent::FETCH_FOO::REPORT_ERROR'
+    };
+    const reducer = dsm(mockOptions()).reducer;
+
+    const actual = reducer(undefined, action).status;
+    const expected = 'idle';
+
+    assert.same(actual, expected, msg);
+    assert.end();
+  });
 });
 
 test('action creators', nest => {


### PR DESCRIPTION
I think this is the most literal implementation possible of Eric Elliott's vision described in issue #5, short of using "eval" (which I don't personally believe is a good option), and without reducer side-effects or other strangeness.  Before I describe this implementation, I want to say I believe it is overly complicated.  I will also be submitting a pull request for an alternate implementation that is less literal, but which achieves the same end and I believe is both more straightforward and more computationally efficient.

The goal of this package is to reduce boilerplate, and the way it does that is by replacing static logic with dynamic logic.  This may come at a very minor processing speed cost: We can't use the "switch" statement (again, assuming we avoid "eval", which again I don't believe is a good option), and instead we must somehow use an "if" statement within the chain of reducers to determine whether to allow state transition based on the current state.  We do have the option of "switching" around a parent/meta reducer as a variable scoped within dsm(), but that would be a side-effect of the reducer and is, imo, also not a good idea.  We could potentially put the current reducer within state, avoiding the side-effect issue, but this just seems bizarre.  And I'm not sure how much either of these options would buy us: Rather than determining which reducer to call prior to processing (but before returning state), we'd be determining which reducer to call next after processing (but still before returning state).

So I believe (and correct me if I'm wrong and other good alternatives exist) in order to implement close-to-one-to-one dynamic logic for the static logic counterpart, we're basically left with making the reducer map deeper and having it grouped by parent status types for later determining which bottom-level reducers are allowed to run to transition state given an initial state.

So, in our nested test case, our reducerMap ends up looking like:

```javascript
reducerMap = {
  idle: {
    'myComponent::FETCH_FOO::INITIALIZE': [Function],
    'myComponent::FETCH_FOO::FETCH': [Function]
  },
  fetching: {
    'myComponent::FETCH_FOO::CANCEL': [Function],
    'myComponent::FETCH_FOO::REPORT_ERROR': [Function],
    'myComponent::FETCH_FOO::REPORT_SUCCESS': [Function]
  },
  error: {
    'myComponent::FETCH_FOO::HANDLE_ERROR': [Function]
  },
  success: {
    'myComponent::FETCH_FOO::HANDLE_SUCCESS': [Function]
  }
}
```

Next, "for each state, [we] build a reducer that only responds to transitions listed for that state in the state graph".  Within this implementation, we do this by creating a parentReducerMap of reducers, one for each possible parent status, which effectively limit the bottom-level reducers to only those which are allowed to transition from the current state.  These parent reducers check for whether a reducer exists for [state][action type] and calls that reducer if it exists.

Finally, the top-level reducer (which is accessible to the end-user) calls the parent reducer for a given state, if it exists.

There are definitely more straightforward and efficient ways of achieving the same end goal, but they diverge further from the static logic analog that we are emulating.  However, I feel like these other options are still superior because dynamic logic is necessarily implemented differently from static logic, and I believe the best solution is the one that is best balance between computational efficiency and straightforwardness.  As I feel that comparatively this option is neither computationally efficient nor straightforward, I do not advocate for the acceptance of this pull request, but am submitting it as an option.