### PR TITLE
Alternate fix for issue 5: Restricts state transition according to graph

### DIFF
--- a/source/test/test.js
+++ b/source/test/test.js
@@ -137,6 +137,34 @@ test('dsm() reducer', nest => {
     assert.same(actual, expected, msg);
     assert.end();
   });
+
+  nest.test('with nested state', assert => {
+    const msg = 'should transition to correct state';
+    const action = {
+      type: 'myComponent::FETCH_FOO::FETCH'
+    };
+    const reducer = dsm(mockOptions()).reducer;
+
+    const actual = reducer(undefined, action).status;
+    const expected = 'fetching';
+
+    assert.same(actual, expected, msg);
+    assert.end();
+  });
+
+  nest.test('with nested state', assert => {
+    const msg = 'should ignore invalid action for current state';
+    const action = {
+      type: 'myComponent::FETCH_FOO::REPORT_ERROR'
+    };
+    const reducer = dsm(mockOptions()).reducer;
+
+    const actual = reducer(undefined, action).status;
+    const expected = 'idle';
+
+    assert.same(actual, expected, msg);
+    assert.end();
+  });
 });
 
 test('action creators', nest => {


### PR DESCRIPTION
Compared to pull request #17, this implementation diverges much more from Eric Elliott's vision for issue #5.  Instead of attempting to create the closest dynamic logic analog of the static logic we typically implement in redux, this implementation just seeks to put out a strong balance between computational efficiency and implementation straightforwardness.

In this implementation, reducers within the reducer map are called for every action they handle regardless of the current state.  But, each reducer checks whether their state transition is allowed from the current state via:

```javascript
if (state.status === a.parentStatus && ...) {
```

This means that yes, the reducer is still ultimately called regardless of whether the state transition it performs is allowed.  But adding in-between steps and additional functions doesn't change the fact that this check must be performed somehow for every action that is dispatched.  And the in-between steps and additional functions do add additional processing time without improving the efficiency of the actual check (it's hard to improve upon a simple string comparison).