### PR TITLE
Fix for Issue 19: Makes actions into a map with action names for keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ const fetchingStates = [
 //   description?: String,
 //   actionStates: Array,
 //   delimiter?: String
-// }) => { actions: Array, actionCreators: Object, reducer: Function }
+// }) => { actions: Object, actionCreators: Object, reducer: Function }
 const foo = dsm({
   component: 'myComponent',
   description: 'fetch foo',
@@ -93,20 +93,20 @@ const foo = dsm({
 });
 ```
 
-## .actions: [...String]
+## .actions: Object
 
-`actions` is an array of strings. If you use the returned `.actionCreators`, you probably don't need to use these, but it's handy for debugging. For the above example, it returns:
+`actions` is an object with camelCased keys and strings corresponding to your state transitions. If you use the returned `.actionCreators`, you probably don't need to use these, but it's handy for debugging. For the above example, it returns:
 
 ```js
-  "actions": [
-    "myComponent::FETCH_FOO::INITIALIZE",
-    "myComponent::FETCH_FOO::FETCH",
-    "myComponent::FETCH_FOO::CANCEL",
-    "myComponent::FETCH_FOO::REPORT_ERROR",
-    "myComponent::FETCH_FOO::HANDLE_ERROR",
-    "myComponent::FETCH_FOO::REPORT_SUCCESS",
-    "myComponent::FETCH_FOO::HANDLE_SUCCESS"
-  ]
+  "actions": {
+    "initialize": "myComponent::FETCH_FOO::INITIALIZE",
+    "fetch": "myComponent::FETCH_FOO::FETCH",
+    "cancel": "myComponent::FETCH_FOO::CANCEL",
+    "reportError": "myComponent::FETCH_FOO::REPORT_ERROR",
+    "handleError": "myComponent::FETCH_FOO::HANDLE_ERROR",
+    "reportSuccess": "myComponent::FETCH_FOO::REPORT_SUCCESS",
+    "handleSuccess": "myComponent::FETCH_FOO::HANDLE_SUCCESS"
+  }
 ```
 
 ## .actionCreators: Object

--- a/source/dsm.js
+++ b/source/dsm.js
@@ -58,6 +58,7 @@ const dsm = ({
   actionStates = []
 }) => {
   const states = [...getStates(actionStates)];
+  const actionNames = getActionCreatorNames(states);
 
   const actionMap = states.map(a => {
     const action = component + [
@@ -75,7 +76,10 @@ const dsm = ({
       parentStatus
     };
   });
-  const actions = actionMap.map(a => a.action);
+  const actions = actionMap.map(a => a.action).reduce((acs, action, i) => {
+    acs[actionNames[i]] = action;
+    return acs;
+  }, {});
 
   const reducerMap = actionMap.reduce((map, a) => {
     map[a.action] = (state = defaultState, action = {}) => {
@@ -95,10 +99,9 @@ const dsm = ({
   }, {});
 
   const reducer = createReducer(defaultState, reducerMap);
-  const actionCreatorNames = getActionCreatorNames(states);
-  const actionCreators = actionCreatorNames.reduce((acs, description, i) => {
+  const actionCreators = actionNames.reduce((acs, description) => {
     acs[description] = payload => ({
-      type: actions[i],
+      type: actions[description],
       payload
     });
 

--- a/source/test/test.js
+++ b/source/test/test.js
@@ -137,6 +137,34 @@ test('dsm() reducer', nest => {
     assert.same(actual, expected, msg);
     assert.end();
   });
+
+  nest.test('with nested state', assert => {
+    const msg = 'should transition to correct state';
+    const action = {
+      type: 'myComponent::FETCH_FOO::FETCH'
+    };
+    const reducer = dsm(mockOptions()).reducer;
+
+    const actual = reducer(undefined, action).status;
+    const expected = 'fetching';
+
+    assert.same(actual, expected, msg);
+    assert.end();
+  });
+
+  nest.test('with nested state', assert => {
+    const msg = 'should ignore invalid action for current state';
+    const action = {
+      type: 'myComponent::FETCH_FOO::REPORT_ERROR'
+    };
+    const reducer = dsm(mockOptions()).reducer;
+
+    const actual = reducer(undefined, action).status;
+    const expected = 'idle';
+
+    assert.same(actual, expected, msg);
+    assert.end();
+  });
 });
 
 test('action creators', nest => {

--- a/source/test/test.js
+++ b/source/test/test.js
@@ -59,15 +59,15 @@ test('dsm() action types', nest => {
   nest.test('flat state', assert => {
     const msg = 'should return action types corresponding with given transitions';
 
-    const expected = [
-      'myComponent::FETCH_FOO::INITIALIZE',
-      'myComponent::FETCH_FOO::FETCH',
-      'myComponent::FETCH_FOO::CANCEL',
-      'myComponent::FETCH_FOO::REPORT_ERROR',
-      'myComponent::FETCH_FOO::HANDLE_ERROR',
-      'myComponent::FETCH_FOO::REPORT_SUCCESS',
-      'myComponent::FETCH_FOO::HANDLE_SUCCESS'
-    ];
+    const expected = {
+      initialize: 'myComponent::FETCH_FOO::INITIALIZE',
+      fetch: 'myComponent::FETCH_FOO::FETCH',
+      cancel: 'myComponent::FETCH_FOO::CANCEL',
+      reportError: 'myComponent::FETCH_FOO::REPORT_ERROR',
+      handleError: 'myComponent::FETCH_FOO::HANDLE_ERROR',
+      reportSuccess: 'myComponent::FETCH_FOO::REPORT_SUCCESS',
+      handleSuccess: 'myComponent::FETCH_FOO::HANDLE_SUCCESS'
+    };
     const actual = dsm(mockOptions({
       actionStates: createFlatStates()
     })).actions;
@@ -79,15 +79,15 @@ test('dsm() action types', nest => {
   nest.test('nested state', assert => {
     const msg = 'should return action types corresponding with given transitions';
 
-    const expected = [
-      'myComponent::FETCH_FOO::INITIALIZE',
-      'myComponent::FETCH_FOO::FETCH',
-      'myComponent::FETCH_FOO::CANCEL',
-      'myComponent::FETCH_FOO::REPORT_ERROR',
-      'myComponent::FETCH_FOO::HANDLE_ERROR',
-      'myComponent::FETCH_FOO::REPORT_SUCCESS',
-      'myComponent::FETCH_FOO::HANDLE_SUCCESS'
-    ];
+    const expected = {
+      initialize: 'myComponent::FETCH_FOO::INITIALIZE',
+      fetch: 'myComponent::FETCH_FOO::FETCH',
+      cancel: 'myComponent::FETCH_FOO::CANCEL',
+      reportError: 'myComponent::FETCH_FOO::REPORT_ERROR',
+      handleError: 'myComponent::FETCH_FOO::HANDLE_ERROR',
+      reportSuccess: 'myComponent::FETCH_FOO::REPORT_SUCCESS',
+      handleSuccess: 'myComponent::FETCH_FOO::HANDLE_SUCCESS'
+    };
     const actual = dsm(mockOptions()).actions;
 
     assert.same(actual, expected, msg);


### PR DESCRIPTION
As this fundamentally changes the exposed interface of `dsm`, **this is a breaking change**.

As discussed in #19, it is useful to be able to access the actions the same way we access the action creators using the `actionCreatorNames` (which I've renamed `actionNames`).  I have implemented this by basically stealing the original methodology that built the action creators map and now use it to build the actions.  This in turn required changing the way the action creators map is built, but only trivially.

I have updated the tests and README to reflect the change of the `actions` data structure.