### PR TITLE
Add getStatus selector.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ By default, the `payload` key is an object with `type: 'empty'`.
 
 ## .getStatus
 
-`getStatus` is a selector, which returns the current status. It takes into account the slice name you provided to Redux-dsm as `component`.
+`getStatus` is a selector which returns the current status. It takes into account the slice name you provided to Redux-dsm as `component`.
 
 ```js
 const slice = 'user-authentication';

--- a/README.md
+++ b/README.md
@@ -88,7 +88,12 @@ const fetchingStates = ['initial', 'idle',
 //   description?: String,
 //   actionStates: Array,
 //   delimiter?: String
-// }) => { actions: Object, actionCreators: Object, reducer: Function }
+// }) => { 
+//   actions: Object,
+//   actionCreators: Object,
+//   getStatus: Function,
+//   reducer: Function
+// }
 const foo = dsm({
   component: 'myComponent',
   description: 'fetch foo',
@@ -135,3 +140,21 @@ handleSuccess()
 The state object will have two keys, `status` and `payload`. In the example above, `status` will be one of `idle`, `fetching`, `error`, or `success`.
 
 By default, the `payload` key is an object with `type: 'empty'`.
+
+## .getStatus
+
+`getStatus` is a selector, which returns the current status. It takes into account the slice name you provided to Redux-dsm as `component`.
+
+```js
+const slice = 'user-authentication';
+
+const foo = dsm({
+  component: slice,
+  description: 'fetch foo',
+  actionStates: fetchingStates
+});
+
+const rootReducer = combineReducers({ [slice]: foo.reducer });
+
+getStatus(rootReducer()); // returns initial status of foo
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1798,7 +1798,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1819,12 +1820,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1839,17 +1842,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1966,7 +1972,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1978,6 +1985,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1992,6 +2000,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1999,12 +2008,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2023,6 +2034,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2103,7 +2115,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2115,6 +2128,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2200,7 +2214,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2236,6 +2251,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2255,6 +2271,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2298,12 +2315,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2411,6 +2430,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -2755,7 +2775,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -2777,6 +2798,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -3324,6 +3346,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
+      "optional": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
@@ -3901,13 +3924,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
       "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "repeat-string": {
       "version": "1.6.1",

--- a/source/dsm.js
+++ b/source/dsm.js
@@ -40,8 +40,7 @@ const createReducer = (defaultState, reducerMap) => {
 
     const reducer = Array.isArray(reducerMap[type]) ?
       composeReducers(...reducerMap[type]) :
-      state => state
-    ;
+      state => state;
 
     return reducer(state, action);
   };
@@ -122,9 +121,12 @@ const dsm = ({
     return acs;
   }, {});
 
+  const getStatus = state => state[component].status;
+
   return {
     actions,
     actionCreators,
+    getStatus,
     reducer
   };
 };

--- a/source/test/authenticate-flow-test.js
+++ b/source/test/authenticate-flow-test.js
@@ -7,6 +7,8 @@ const AUTHENTICATING = 'authenticating';
 const ERROR = 'error';
 const SIGNED_IN = 'signed in';
 
+const slice = 'user-authentication';
+
 const actionStates = ['initial', SIGNED_OUT,
   ['sign in', AUTHENTICATING,
     ['report sign in failure', ERROR,
@@ -26,9 +28,10 @@ const {
   actionCreators: {
     signIn,
     reportSignInSuccess
-  }
+  },
+  getStatus
 } = dsm({
-  component: 'user-authentication',
+  component: slice,
   description: 'authenticate user',
   actionStates
 });
@@ -41,7 +44,7 @@ describe('userAuthenticationReducer', async assert => {
     assert({
       given: '["initial", "signed out", /*...*/',
       should,
-      actual: reducer().status,
+      actual: getStatus({ [slice]: reducer() }),
       expected: SIGNED_OUT
     });
   }
@@ -52,7 +55,7 @@ describe('userAuthenticationReducer', async assert => {
     assert({
       given: 'signed out initial state & signIn action',
       should,
-      actual: reducer(undefined, signIn()).status,
+      actual: getStatus({ [slice]: reducer(undefined, signIn()) }),
       expected: AUTHENTICATING
     });
   }
@@ -64,7 +67,7 @@ describe('userAuthenticationReducer', async assert => {
     assert({
       given: '"authenticating" initial state & reportSignInSuccess action',
       should,
-      actual: reducer(initialState, reportSignInSuccess()).status,
+      actual: getStatus({ [slice]: reducer(initialState, reportSignInSuccess()) }),
       expected: SIGNED_IN
     });
   }
@@ -75,7 +78,7 @@ describe('userAuthenticationReducer', async assert => {
     assert({
       given: '"signed out" initial state & reportSignInSuccess action',
       should,
-      actual: reducer(undefined, reportSignInSuccess()).status,
+      actual: getStatus({ [slice]: reducer(undefined, reportSignInSuccess()) }),
       expected: SIGNED_IN
     });
   }

--- a/source/test/test.js
+++ b/source/test/test.js
@@ -228,3 +228,35 @@ test('action creators', nest => {
     assert.end();
   });
 });
+
+test('selectors', nest => {
+  nest.test('getStatus with the default state', assert => {
+    const msg = 'should return the correct state';
+
+    const { reducer, getStatus } = dsm(mockOptions());
+    const rootState = { [mockOptions().component]: reducer() };
+
+    const expected = 'idle';
+
+    const actual = getStatus(rootState);
+
+    assert.same(actual, expected, msg);
+    assert.end();
+  });
+
+  nest.test('functions with state', assert => {
+    const msg = 'should return the correct state';
+
+    const { actionCreators, reducer, getStatus } = dsm(mockOptions());
+    const rootState = {
+      [mockOptions().component]: reducer(undefined, actionCreators.fetch())
+    };
+
+    const expected = 'fetching';
+
+    const actual = getStatus(rootState);
+
+    assert.same(actual, expected, msg);
+    assert.end();
+  });
+});


### PR DESCRIPTION
Related to https://github.com/ericelliott/redux-dsm/issues/30.

I wanted to have a neat selector for Redux-dsm. This PR introduces `getStatus`, which lets you grab the current status in `mapStateToProps`. We might want to change the name of `component` in the `dsm` API to `slice` (similar to Autodux).

Also if we can come up with a good API we could auto generate selectors for each state. The problem I had with this is the following. Let's say you have a state & transitions like this:

```js
const mockStates = ['initial', 'idle',
  ['fetch', 'fetching',
    ['cancel', 'idle'],
    ['report error', 'error',
      ['handle error', 'idle']
    ],
    ['report success', 'success',
      ['handle success', 'idle']
    ]
  ]
];
```

You can't just name the selectors `is` + status camel-cased, because `isError` doesn't make sense, even though `isFetching` does. The opposite is true, too. If you use `has` + status` you get `hasError` and `hasFetching`. Maybe we could name the selectors `statusIs` + status (`statusIsFetching`, `statusIsError` etc 🤔 )?